### PR TITLE
Explicitly use main pypi repository URL

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,3 +38,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI }}
+        repository_url: https://upload.pypi.org/


### PR DESCRIPTION
For some reason removing the test repository url was not enough. I guess it cached the old value or something?